### PR TITLE
fix: Use lowercase repository name for GHCR

### DIFF
--- a/.github/workflows/image-build-push.yaml
+++ b/.github/workflows/image-build-push.yaml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   DOCKERHUB_IMAGE: sirantd/aws-helm-kubectl
-  GHCR_IMAGE: ghcr.io/${{ github.repository_owner }}/aws-helm-kubectl
+  GHCR_IMAGE: ghcr.io/perun-engineering/aws-helm-kubectl
 
 jobs:
   define:


### PR DESCRIPTION
GHCR repository names must be lowercase. Fixed reference from ghcr.io/Perun-Engineering/aws-helm-kubectl to
ghcr.io/perun-engineering/aws-helm-kubectl