### PR TITLE
chore: Add workflow permissions for version check

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -6,6 +6,10 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   check-versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Fix GitHub Actions workflow error by adding required permissions for creating and updating issues in the version check workflow

## Test plan
- [x] Pre-commit hooks passed
- [ ] Verify workflow runs without permission errors